### PR TITLE
Copied in basic config for kubernetes.

### DIFF
--- a/conf/couchbase/filter/filter-add-common-info-kubernetes.conf
+++ b/conf/couchbase/filter/filter-add-common-info-kubernetes.conf
@@ -1,0 +1,56 @@
+# Add information for this container as standard keys: https://docs.fluentbit.io/manual/pipeline/filters/modify
+# This will simplify downstream parsing to filter the different pod logs.
+# This file and filter set is meant to only be used with the Couchbase Autonomous Operator deployments on Kubernetes.
+# Missing variables will report an error in the fluent bit log but this can be ignored.
+[FILTER]
+    Name record_modifier
+    Alias common_info_modifier
+    Match couchbase.log.*
+    Record hostname ${HOSTNAME}
+    Record logshipper couchbase.sidecar.fluentbit
+    # These should be built into the container
+    Record couchbase.logging.version ${COUCHBASE_FLUENTBIT_VERSION}
+    Record fluentbit.version ${FLUENTBIT_VERSION}
+    # The following are set by the operator from the pod meta-data, they may not exist on normal containers
+    Record pod.namespace ${POD_NAMESPACE}
+    Record pod.name ${POD_NAME}
+    Record pod.uid ${POD_UID}
+    # The following come from kubernetes annotations and labels set as env vars so also may not exist
+    Record couchbase.cluster ${couchbase_cluster}
+    Record couchbase.operator.version ${operator.couchbase.com/version}
+    Record couchbase.server.version ${server.couchbase.com/version}
+    Record couchbase.node ${couchbase_node}
+    Record couchbase.node-config ${couchbase_node_conf}
+    Record couchbase.server.server ${couchbase_server}
+    # These are config dependent so will trigger a failure if missing but this can be ignored
+    Record couchbase.analytics ${couchbase_service_analytics}
+    Record couchbase.data ${couchbase_service_data}
+    Record couchbase.eventing ${couchbase_service_eventing}
+    Record couchbase.index ${couchbase_service_index}
+    Record couchbase.query ${couchbase_service_query}
+    Record couchbase.search ${couchbase_service_search}
+
+# The filter cannot auto-nest so we can do that now to tidy things up that are related.
+[FILTER]
+    Name nest
+    Alias pod_common_info_nest
+    Match couchbase.log.*
+    Operation nest
+    Wildcard pod.*
+    Nest_under pod
+    Remove_prefix pod.
+
+[FILTER]
+    Name nest
+    Alias couchbase_common_info_nest
+    Match couchbase.log.*
+    Operation nest
+    Wildcard couchbase.*
+    Nest_under couchbase
+    Remove_prefix couchbase.
+
+[Filter]
+    Name    lua
+    Match   couchbase.log.*
+    script  /fluent-bit/etc/common.lua
+    call    set_hostname

--- a/conf/couchbase/input/in-tail-query-log.conf
+++ b/conf/couchbase/input/in-tail-query-log.conf
@@ -3,7 +3,7 @@
     Name tail
     Alias query_tail
     Path ${COUCHBASE_LOGS}/query.log
-    Parser couchbase_simple_log
+    Parser couchbase_simple_log_mixed
     Refresh_Interval 10
     Skip_Long_Lines On
     Skip_Empty_Lines On

--- a/conf/couchbase/parsers-couchbase.conf
+++ b/conf/couchbase/parsers-couchbase.conf
@@ -57,7 +57,7 @@
 [PARSER]
     Name         couchbase_simple_log_mixed
     Format       regex
-    Regex        ^(?<timestamp>\d+(-|/)\d+(-|/)\d+(T|\s+)\d+:\d+:\d+(\.\d+(\+|-)\d+:\d+|))\s+((\[)?(?<level>\w+)(\]|:))\s*(?<message>.*)$
+    Regex        ^(_time=)?(?<timestamp>\d+(-|\/)\d+(-|\/)\d+(T|\s+)\d+:\d+:\d+(\.\d+(\+|-)\d+:\d+|))\s+((\[|_level=)(?<level>[A-Za-z]+)\]?)?(?<message>.*)
     Time_Key     timestamp
     Time_Keep    On
 # We cannot parse the time as different formats directly, it could be done downstream and/or left as current time

--- a/conf/fluent-bit-kubernetes.conf
+++ b/conf/fluent-bit-kubernetes.conf
@@ -1,0 +1,54 @@
+@include /fluent-bit/etc/couchbase/service.conf
+
+# We split up the input configuration to simplify reuse in testing and custom configurations (so you don't have to repeat it).
+# @include /fluent-bit/etc/couchbase/input/in-*.conf
+# Each of the logs should have a tag: couchbase.log.<logname>.
+@include /fluent-bit/etc/couchbase/input/in-tail-audit-log.conf
+@include /fluent-bit/etc/couchbase/input/in-tail-xdcr-log.conf
+@include /fluent-bit/etc/couchbase/input/in-tail-indexer-log.conf
+@include /fluent-bit/etc/couchbase/input/in-tail-projector-log.conf
+@include /fluent-bit/etc/couchbase/input/in-tail-memcached-log.conf
+
+# erlang multiline logs
+@include /fluent-bit/etc/couchbase/input/in-tail-babysitter-log.conf
+@include /fluent-bit/etc/couchbase/input/in-tail-couchdb-log.conf
+@include /fluent-bit/etc/couchbase/input/in-tail-debug-log.conf
+@include /fluent-bit/etc/couchbase/input/in-tail-json_rpc-log.conf
+@include /fluent-bit/etc/couchbase/input/in-tail-mapreduce_errors-log.conf
+@include /fluent-bit/etc/couchbase/input/in-tail-metakv-log.conf
+@include /fluent-bit/etc/couchbase/input/in-tail-ns_couchdb-log.conf
+@include /fluent-bit/etc/couchbase/input/in-tail-reports-log.conf
+
+@include /fluent-bit/etc/couchbase/input/in-tail-analytics-log.conf
+
+@include /fluent-bit/etc/couchbase/input/in-tail-eventing-log.conf
+@include /fluent-bit/etc/couchbase/input/in-tail-fts-log.conf
+
+@include /fluent-bit/etc/couchbase/input/in-tail-http-log.conf
+@include /fluent-bit/etc/couchbase/input/in-tail-rebalance-report.conf
+@include /fluent-bit/etc/couchbase/input/in-tail-prometheus-log.conf
+
+# Optionally include this if you want all other logs with a couchbase.raw.log.<logname> tag.
+# Not included by default to keep loading down.
+# @include /fluent-bit/etc/couchbase/ignore-raw-log.conf
+
+# Deal specifically with some log parsing initially
+@include /fluent-bit/etc/couchbase/filter/filter-handle-logfmt.conf
+
+# Add in common info
+@include /fluent-bit/etc/couchbase/filter/filter-add-common-info-kubernetes.conf
+
+# Deal with missing/incorrect level & filename information
+@include /fluent-bit/etc/couchbase/filter/filter-handle-levels.conf
+@include /fluent-bit/etc/couchbase/filter/filter-handle-filenames.conf
+
+# Optionally include this to get common problems duplicated to a specific stream
+# @include /fluent-bit/etc/couchbase/filter-common-problems.conf
+
+# Output all parsed Couchbase logs by default
+@include /fluent-bit/etc/couchbase/output/out-stdout.conf
+
+# The Loki output plugin is enabled by default but does not match anything.
+@include /fluent-bit/etc/couchbase/output/out-loki.conf
+@include /fluent-bit/etc/couchbase/output/out-elastic.conf
+@include /fluent-bit/etc/couchbase/output/out-splunk.conf

--- a/conf/fluent-bit-simple.conf
+++ b/conf/fluent-bit-simple.conf
@@ -1,0 +1,15 @@
+# Cut down version with no real work in it to use for testing/debug
+@include /fluent-bit/etc/couchbase/service.conf
+
+# Just pull in all logs with no parsing at all or Multiline support
+[INPUT]
+    Name tail
+    Alias simple_tail
+    Path ${COUCHBASE_LOGS}/*.log
+    Refresh_Interval 10
+    Skip_Long_Lines On
+    Path_Key filename
+    Tag couchbase.log.<logname>
+    Tag_Regex ${COUCHBASE_LOGS}/(?<logname>[^.]+).log$
+
+@include /fluent-bit/etc/couchbase/output/out-stdout.conf


### PR DESCRIPTION
These files are 1:1 copies of the configuration from couchbase-fluent-bit, to maintain compatibility with previous versions.