### PR TITLE
updated simple_log_mixed parser.

### DIFF
--- a/conf/couchbase/input/in-tail-query-log.conf
+++ b/conf/couchbase/input/in-tail-query-log.conf
@@ -3,7 +3,7 @@
     Name tail
     Alias query_tail
     Path ${COUCHBASE_LOGS}/query.log
-    Parser couchbase_simple_log
+    Parser couchbase_simple_log_mixed
     Refresh_Interval 10
     Skip_Long_Lines On
     Skip_Empty_Lines On

--- a/conf/couchbase/parsers-couchbase.conf
+++ b/conf/couchbase/parsers-couchbase.conf
@@ -57,7 +57,7 @@
 [PARSER]
     Name         couchbase_simple_log_mixed
     Format       regex
-    Regex        ^(?<timestamp>\d+(-|/)\d+(-|/)\d+(T|\s+)\d+:\d+:\d+(\.\d+(\+|-)\d+:\d+|))\s+((\[)?(?<level>\w+)(\]|:))\s*(?<message>.*)$
+    Regex        ^(_time=)?(?<timestamp>\d+(-|\/)\d+(-|\/)\d+(T|\s+)\d+:\d+:\d+(\.\d+(\+|-)\d+:\d+|))\s+((\[|_level=)(?<level>[A-Za-z]+)\]?)?(?<message>.*)
     Time_Key     timestamp
     Time_Keep    On
 # We cannot parse the time as different formats directly, it could be done downstream and/or left as current time


### PR DESCRIPTION
mixed logs would occasionally start with _time, which was not caught by regex.
i.e
```
2021/03/09 17:32:15 cbauth: key: fts/remoteClients registered for tls config updates
_time=2021-03-09T17:32:15.241+00:00 _level=INFO _msg= Initialization of cbauth succeeded  
_
```
Extended regex to catch this.